### PR TITLE
Extended Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   BUILD_TYPE: Debug
@@ -15,150 +15,146 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ./bin/test
-      
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ./bin/test
+
   build-ubuntu-clang:
     name: ubuntu-clang
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+      - uses: actions/checkout@v4
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ./bin/test
-      
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ./bin/test
+
   build-macos:
     name: macos
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ./bin/test
-      
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ./bin/test
+
   build-windows:
     name: windows
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
+      - name: Setup MSVC dev command prompt
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        with:
+          arch: x64
 
-    - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@v3
-      with:
-        arch: x64
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+        # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-      # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ./bin/${{env.BUILD_TYPE}}/test
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ./bin/${{env.BUILD_TYPE}}/test
-      
   samples-windows-static:
     name: samples-windows-static
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
+      - name: Setup MSVC dev command prompt
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        with:
+          arch: x64
 
-    - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@v3
-      with:
-        arch: x64
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-      
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
 
   samples-windows-dynamic:
     name: samples-windows-dynamic
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
+      - name: Setup MSVC dev command prompt
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        with:
+          arch: x64
 
-    - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@v3
-      with:
-        arch: x64
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
-      
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
 
   samples-macos-static:
     name: samples-macos-static
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-      
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
 
   samples-macos-dynamic:
     name: samples-macos-dynamic
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
-      
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
 
   samples-ubuntu-gcc-static:
     name: samples-ubuntu-gcc-static
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install X11, Wayland & GL development libraries
-      run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev
+      - name: Install X11, Wayland & GL development libraries
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-      
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
-      
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,38 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: ./bin/test
 
+  build-ubuntu-gcc-arm64:
+    name: ubuntu-gcc-arm64
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross-compilation tools
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  build-ubuntu-clang-arm64:
+    name: ubuntu-clang-arm64
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross-compilation tools
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
   build-macos:
     name: macos
     runs-on: macos-latest
@@ -155,6 +187,22 @@ jobs:
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
+
+  samples-ubuntu-gcc-static-arm64:
+    name: samples-ubuntu-gcc-static-arm64
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross-compilation tools
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: |
-      ${{ matrix.runs_on.name }}${{ matrix.compiler.name }}${{ matrix.build_type.id }}
+      ${{ matrix.runs_on.name }}${{ matrix.compiler.name }}${{ matrix.build_type.name }}
     runs-on: ${{ matrix.runs_on.runner }}
     timeout-minutes: 10
     strategy:
@@ -40,8 +40,10 @@ jobs:
 
         compiler:
           - name: -clang
+            id: clang
             cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
           - name: ""
+            id: default
             cmake_compiler_flags: ""
 
         build_type:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,39 +8,40 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.runs_on.id }}-${{ matrix.compiler.id }}-${{ matrix.build_type.id }}
+    name: |
+      ${{ matrix.runs_on.name }}${{ matrix.compiler.name == 'default' ? '' : '-' + matrix.compiler.name }}${{ matrix.build.id == 'basic' ? '' : '-' + matrix.build.id }}
     runs-on: ${{ matrix.runs_on.runner }}
     timeout-minutes: 10
     strategy:
       matrix:
         runs_on:
-          - id: ubuntu-latest
+          - name: ubuntu
             runner: ubuntu-latest
             test_path: "./bin/test"
             cmake_system_flags: ""
-          - id: ubuntu-24.04-arm64
+          - name: ubuntu-arm
             runner: ubuntu-24.04-arm64
             test_path: "./bin/test"
             cmake_system_flags: ""
-          - id: macos-latest
+          - name: macos
             runner: macos-latest
             test_path: "./bin/test"
             cmake_system_flags: ""
-          - id: windows-latest
+          - name: windows
             runner: windows-latest
             msvc_arch: x64
             test_path: "./bin/Debug/test"
             cmake_system_flags: ""
-          - id: windows-11-arm
+          - name: windows-arm
             runner: windows-11-arm
             msvc_arch: arm64
             test_path: "./bin/Debug/test"
             cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
 
         compiler:
-          - id: clang
+          - name: clang
             cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
-          - id: default
+          - name: default
             cmake_compiler_flags: ""
 
         build_type:
@@ -100,7 +101,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies (Ubuntu samples)
-        if: ${{ matrix.runs_on.id == 'ubuntu-latest' && (matrix.build_type.id == 'samples-static' || matrix.build_type.id == 'samples-dynamic') }}
+        if: ${{ matrix.runs_on.runner == 'ubuntu-latest' && (matrix.build_type.id == 'samples-static' || matrix.build_type.id == 'samples-dynamic') }}
         run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev
 
       - name: Setup MSVC dev command prompt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,42 +14,42 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ubuntu GCC x64 basic
+          # Ubuntu GCC x64
           - name: ubuntu-gcc
             runs_on: ubuntu-latest
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
-          # Ubuntu Clang x64 basic
+          # Ubuntu Clang x64
           - name: ubuntu-clang
             runs_on: ubuntu-latest
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
-          # Ubuntu GCC ARM64 basic (cross-compile)
+          # Ubuntu GCC ARM64
           - name: ubuntu-gcc-arm64
-            runs_on: ubuntu-latest
-            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            runs_on: ubuntu-24.04-arm64
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             cmake_build: "cmake --build build --config Debug"
+            test_command: "./bin/test"
 
-          # Ubuntu Clang ARM64 basic (cross-compile)
+          # Ubuntu Clang ARM64
           - name: ubuntu-clang-arm64
-            runs_on: ubuntu-latest
-            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            runs_on: ubuntu-24.04-arm64
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             cmake_build: "cmake --build build --config Debug"
+            test_command: "./bin/test"
 
-          # macOS x64 basic
+          # macOS x64
           - name: macos
             runs_on: macos-latest
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
-          # Windows x64 basic
+          # Windows x64
           - name: windows
             runs_on: windows-latest
             msvc_arch: x64
@@ -57,7 +57,7 @@ jobs:
             cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/Debug/test"
 
-          # Windows ARM64 basic
+          # Windows ARM64
           - name: windows-arm64
             runs_on: windows-11-arm
             msvc_arch: arm64
@@ -71,7 +71,6 @@ jobs:
             install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
             cmake_build: "cmake --build build --config Release"
-
 
           # macOS samples static
           - name: samples-macos-static

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI Build
 
 on:
   push:
-    branches: [main, ext-build]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,95 +8,116 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.runs_on }}-${{ matrix.compiler }}-${{ matrix.build_type }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 10
     strategy:
       matrix:
+        runs_on:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm64,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+          ]
+        compiler: [clang, default]
+        build_type: [basic, samples-static, samples-dynamic]
         include:
-          # Ubuntu GCC x64
-          - name: ubuntu-gcc
-            runs_on: ubuntu-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/test"
+          # Build type defaults
+          - build_type: basic
+            cmake_build_type: Debug
+            cmake_samples: OFF
+            cmake_shared_libs: OFF
+            cmake_unit_tests: ON
+            cmake_sanitize: ON
+            cmake_validate: ON
+            cmake_warning_as_error: ON
+            build_config: Debug
+            run_tests: true
 
-          # Ubuntu Clang x64
-          - name: ubuntu-clang
-            runs_on: ubuntu-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/test"
+          - build_type: samples-static
+            cmake_build_type: Release
+            cmake_samples: ON
+            cmake_shared_libs: OFF
+            cmake_unit_tests: OFF
+            cmake_sanitize: OFF
+            cmake_validate: OFF
+            cmake_warning_as_error: OFF
+            build_config: Release
+            run_tests: false
 
-          # Ubuntu GCC ARM64
-          - name: ubuntu-gcc-arm64
-            runs_on: ubuntu-24.04-arm64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/test"
+          - build_type: samples-dynamic
+            cmake_build_type: Release
+            cmake_samples: ON
+            cmake_shared_libs: ON
+            cmake_unit_tests: OFF
+            cmake_sanitize: OFF
+            cmake_validate: OFF
+            cmake_warning_as_error: OFF
+            build_config: Release
+            run_tests: false
 
-          # Ubuntu Clang ARM64
-          - name: ubuntu-clang-arm64
-            runs_on: ubuntu-24.04-arm64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/test"
+          # Compiler flags
+          - compiler: clang
+            cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
+          - compiler: default
+            cmake_compiler_flags: ""
 
-          # macOS x64
-          - name: macos
-            runs_on: macos-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/test"
+          # Platform-specific settings
+          - runs_on: ubuntu-latest
+            test_path: "./bin/test"
+            cmake_system_flags: ""
 
-          # Windows x64
-          - name: windows
-            runs_on: windows-latest
+          - runs_on: ubuntu-24.04-arm64
+            test_path: "./bin/test"
+            cmake_system_flags: ""
+
+          - runs_on: macos-latest
+            test_path: "./bin/test"
+            cmake_system_flags: ""
+
+          - runs_on: windows-latest
             msvc_arch: x64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/Debug/test"
+            test_path: "./bin/Debug/test"
+            cmake_system_flags: ""
 
-          # Windows ARM64
-          - name: windows-arm64
-            runs_on: windows-11-arm
+          - runs_on: windows-11-arm
             msvc_arch: arm64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build build --config Debug"
-            test_command: "./bin/Debug/test"
+            test_path: "./bin/Debug/test"
+            cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
 
-          # Ubuntu GCC samples static
-          - name: samples-ubuntu-gcc-static
-            runs_on: ubuntu-latest
+          # Ubuntu sample dependencies
+          - runs_on: ubuntu-latest
+            build_type: samples-static
             install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
 
-          # macOS samples static
-          - name: samples-macos-static
-            runs_on: macos-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
+        exclude:
+          # Only Ubuntu supports multiple compilers
+          - runs_on: macos-latest
+            compiler: clang
+          - runs_on: windows-latest
+            compiler: clang
+          - runs_on: windows-11-arm
+            compiler: clang
 
-          # macOS samples dynamic
-          - name: samples-macos-dynamic
-            runs_on: macos-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
+          # ARM platforms don't support samples
+          - runs_on: ubuntu-24.04-arm64
+            build_type: samples-static
+          - runs_on: ubuntu-24.04-arm64
+            build_type: samples-dynamic
+          - runs_on: windows-11-arm
+            build_type: samples-static
+          - runs_on: windows-11-arm
+            build_type: samples-dynamic
 
-          # Windows x64 samples static
-          - name: samples-windows-static
-            runs_on: windows-latest
-            msvc_arch: x64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # Windows x64 samples dynamic
-          - name: samples-windows-dynamic
-            runs_on: windows-latest
-            msvc_arch: x64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
+          # Temp disabled
+          # - runs_on: ubuntu-latest
+          #   compiler: clang
+          #   build_type: samples-static
+          # - runs_on: ubuntu-latest
+          #   compiler: clang
+          #   build_type: samples-dynamic
 
     steps:
       - uses: actions/checkout@v4
@@ -112,12 +133,12 @@ jobs:
           arch: ${{ matrix.msvc_arch }}
 
       - name: Configure CMake
-        run: ${{ matrix.cmake_configure }}
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ${{ matrix.cmake_compiler_flags }} ${{ matrix.cmake_system_flags }} -DBOX2D_SAMPLES=${{ matrix.cmake_samples }} -DBUILD_SHARED_LIBS=${{ matrix.cmake_shared_libs }} -DBOX2D_UNIT_TESTS=${{ matrix.cmake_unit_tests }} -DBOX2D_SANITIZE=${{ matrix.cmake_sanitize }} -DBOX2D_VALIDATE=${{ matrix.cmake_validate }} -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ matrix.cmake_warning_as_error }}
 
       - name: Build
-        run: ${{ matrix.cmake_build }}
+        run: cmake --build build --config ${{ matrix.build_config }}
 
       - name: Test
-        if: ${{ matrix.test_command }}
+        if: ${{ matrix.run_tests }}
         working-directory: build
-        run: ${{ matrix.test_command }}
+        run: ${{ matrix.test_path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: |
-      ${{ matrix.runs_on.name }}${{ matrix.compiler.name == 'default' ? '' : '-' + matrix.compiler.name }}${{ matrix.build.id == 'basic' ? '' : '-' + matrix.build.id }}
+      ${{ matrix.runs_on.name }}${{ matrix.compiler.name }}${{ matrix.build.id }}
     runs-on: ${{ matrix.runs_on.runner }}
     timeout-minutes: 10
     strategy:
@@ -39,13 +39,14 @@ jobs:
             cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
 
         compiler:
-          - name: clang
+          - name: -clang
             cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
-          - name: default
+          - name: ""
             cmake_compiler_flags: ""
 
         build_type:
-          - id: basic
+          - name: ""
+            id: basic
             cmake_build_type: Debug
             cmake_samples: OFF
             cmake_shared_libs: OFF
@@ -56,7 +57,8 @@ jobs:
             build_config: Debug
             run_tests: true
 
-          - id: samples-static
+          - name: "-samples-static"
+            id: samples-static
             cmake_build_type: Release
             cmake_samples: ON
             cmake_shared_libs: OFF
@@ -67,7 +69,8 @@ jobs:
             build_config: Release
             run_tests: false
 
-          - id: samples-dynamic
+          - name: "-samples-dynamic"
+            id: samples-dynamic
             cmake_build_type: Release
             cmake_samples: ON
             cmake_shared_libs: ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, ext-build]
   pull_request:
     branches: [main]
 
@@ -10,199 +10,138 @@ env:
   BUILD_TYPE: Debug
 
 jobs:
-  build-ubuntu-gcc:
-    name: ubuntu-gcc
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          # Ubuntu GCC x64 basic
+          - name: ubuntu-gcc
+            runs_on: ubuntu-latest
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            test_command: "./bin/test"
+
+          # Ubuntu Clang x64 basic
+          - name: ubuntu-clang
+            runs_on: ubuntu-latest
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            test_command: "./bin/test"
+
+          # Ubuntu GCC ARM64 basic (cross-compile)
+          - name: ubuntu-gcc-arm64
+            runs_on: ubuntu-latest
+            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+
+          # Ubuntu Clang ARM64 basic (cross-compile)
+          - name: ubuntu-clang-arm64
+            runs_on: ubuntu-latest
+            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+
+          # macOS x64 basic
+          - name: macos
+            runs_on: macos-latest
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            test_command: "./bin/test"
+
+          # Windows x64 basic
+          - name: windows
+            runs_on: windows-latest
+            msvc_arch: x64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            test_command: "./bin/${{env.BUILD_TYPE}}/test"
+
+          # Windows ARM64 basic
+          - name: windows-arm64
+            runs_on: windows-11-arm
+            msvc_arch: arm64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            test_command: "./bin/${{env.BUILD_TYPE}}/test"
+
+          # Windows x64 samples static
+          - name: samples-windows-static
+            runs_on: windows-latest
+            msvc_arch: x64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # Windows ARM64 samples static
+          - name: samples-windows-static-arm64
+            runs_on: windows-11-arm
+            msvc_arch: arm64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # Windows x64 samples dynamic
+          - name: samples-windows-dynamic
+            runs_on: windows-latest
+            msvc_arch: x64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # Windows ARM64 samples dynamic
+          - name: samples-windows-dynamic-arm64
+            runs_on: windows-11-arm
+            msvc_arch: arm64
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # macOS samples static
+          - name: samples-macos-static
+            runs_on: macos-latest
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # macOS samples dynamic
+          - name: samples-macos-dynamic
+            runs_on: macos-latest
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # Ubuntu GCC samples static
+          - name: samples-ubuntu-gcc-static
+            runs_on: ubuntu-latest
+            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
+          # Ubuntu GCC ARM64 samples static (cross-compile, samples=OFF)
+          - name: samples-ubuntu-gcc-static-arm64
+            runs_on: ubuntu-latest
+            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ./bin/test
-
-  build-ubuntu-clang:
-    name: ubuntu-clang
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ./bin/test
-
-  build-ubuntu-gcc-arm64:
-    name: ubuntu-gcc-arm64
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install cross-compilation tools
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-  build-ubuntu-clang-arm64:
-    name: ubuntu-clang-arm64
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install cross-compilation tools
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-  build-macos:
-    name: macos
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ./bin/test
-
-  build-windows:
-    name: windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
+      - name: Install dependencies
+        if: ${{ matrix.install_deps }}
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.install_deps }}
 
       - name: Setup MSVC dev command prompt
+        if: ${{ matrix.msvc_arch }}
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
-          arch: x64
+          arch: ${{ matrix.msvc_arch }}
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-        # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF
+        run: ${{ matrix.cmake_configure }}
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        run: ${{ matrix.cmake_build }}
 
       - name: Test
+        if: ${{ matrix.test_command }}
         working-directory: ${{github.workspace}}/build
-        run: ./bin/${{env.BUILD_TYPE}}/test
-
-  samples-windows-static:
-    name: samples-windows-static
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup MSVC dev command prompt
-        uses: TheMrMilchmann/setup-msvc-dev@v3
-        with:
-          arch: x64
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-  samples-windows-dynamic:
-    name: samples-windows-dynamic
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup MSVC dev command prompt
-        uses: TheMrMilchmann/setup-msvc-dev@v3
-        with:
-          arch: x64
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-  samples-macos-static:
-    name: samples-macos-static
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-  samples-macos-dynamic:
-    name: samples-macos-dynamic
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-  samples-ubuntu-gcc-static:
-    name: samples-ubuntu-gcc-static
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install X11, Wayland & GL development libraries
-        run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-  samples-ubuntu-gcc-static-arm64:
-    name: samples-ubuntu-gcc-static-arm64
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install cross-compilation tools
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
+        run: ${{ matrix.test_command }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,107 +17,107 @@ jobs:
           # Ubuntu GCC x64 basic
           - name: ubuntu-gcc
             runs_on: ubuntu-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
           # Ubuntu Clang x64 basic
           - name: ubuntu-clang
             runs_on: ubuntu-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
           # Ubuntu GCC ARM64 basic (cross-compile)
           - name: ubuntu-gcc-arm64
             runs_on: ubuntu-latest
             install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
 
           # Ubuntu Clang ARM64 basic (cross-compile)
           - name: ubuntu-clang-arm64
             runs_on: ubuntu-latest
             install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
 
           # macOS x64 basic
           - name: macos
             runs_on: macos-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/test"
 
           # Windows x64 basic
           - name: windows
             runs_on: windows-latest
             msvc_arch: x64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/Debug/test"
 
           # Windows ARM64 basic
           - name: windows-arm64
             runs_on: windows-11-arm
             msvc_arch: arm64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/Debug/test"
 
           # Windows x64 samples static
           - name: samples-windows-static
             runs_on: windows-latest
             msvc_arch: x64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # Windows ARM64 samples static
           - name: samples-windows-static-arm64
             runs_on: windows-11-arm
             msvc_arch: arm64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # Windows x64 samples dynamic
           - name: samples-windows-dynamic
             runs_on: windows-latest
             msvc_arch: x64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # Windows ARM64 samples dynamic
           - name: samples-windows-dynamic-arm64
             runs_on: windows-11-arm
             msvc_arch: arm64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # macOS samples static
           - name: samples-macos-static
             runs_on: macos-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # macOS samples dynamic
           - name: samples-macos-dynamic
             runs_on: macos-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # Ubuntu GCC samples static
           - name: samples-ubuntu-gcc-static
             runs_on: ubuntu-latest
             install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
           # Ubuntu GCC ARM64 samples static (cross-compile, samples=OFF)
           - name: samples-ubuntu-gcc-static-arm64
             runs_on: ubuntu-latest
             install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config Release"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
 
     steps:
       - uses: actions/checkout@v4
@@ -140,5 +140,5 @@ jobs:
 
       - name: Test
         if: ${{ matrix.test_command }}
-        working-directory: ${{github.workspace}}/build
+        working-directory: build
         run: ${{ matrix.test_command }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,12 @@ jobs:
             test_path: "./bin/Debug/test"
             cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
 
-          # Ubuntu sample dependencies
+          # Sample deps
           - runs_on: ubuntu-latest
             build_type: samples-static
+            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
+          - runs_on: ubuntu-latest
+            build_type: samples-dynamic
             install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
 
         exclude:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: |
-      ${{ matrix.runs_on.name }}${{ matrix.compiler.name }}${{ matrix.build.id }}
+      ${{ matrix.runs_on.name }}${{ matrix.compiler.name }}${{ matrix.build_type.id }}
     runs-on: ${{ matrix.runs_on.runner }}
     timeout-minutes: 10
     strategy:
@@ -82,22 +82,22 @@ jobs:
             run_tests: false
 
         exclude:
-          # Only Ubuntu supports clang in your original config
-          - runs_on: { id: macos-latest }
+          # Only Ubuntu supports clang
+          - runs_on: { runner: macos-latest }
             compiler: { id: clang }
-          - runs_on: { id: windows-latest }
+          - runs_on: { runner: windows-latest }
             compiler: { id: clang }
-          - runs_on: { id: windows-11-arm }
+          - runs_on: { runner: windows-11-arm }
             compiler: { id: clang }
 
           # ARM platforms don't support samples
-          - runs_on: { id: ubuntu-24.04-arm64 }
+          - runs_on: { runner: ubuntu-24.04-arm64 }
             build_type: { id: samples-static }
-          - runs_on: { id: ubuntu-24.04-arm64 }
+          - runs_on: { runner: ubuntu-24.04-arm64 }
             build_type: { id: samples-dynamic }
-          - runs_on: { id: windows-11-arm }
+          - runs_on: { runner: windows-11-arm }
             build_type: { id: samples-static }
-          - runs_on: { id: windows-11-arm }
+          - runs_on: { runner: windows-11-arm }
             build_type: { id: samples-dynamic }
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         runs_on:
           [
             ubuntu-latest,
-            ubuntu-24.04-arm64,
+            ubuntu-24.04-arm,
             macos-latest,
             windows-latest,
             windows-11-arm,
@@ -69,7 +69,7 @@ jobs:
             test_path: "./bin/test"
             cmake_system_flags: ""
 
-          - runs_on: ubuntu-24.04-arm64
+          - runs_on: ubuntu-24.04-arm
             test_path: "./bin/test"
             cmake_system_flags: ""
 
@@ -105,9 +105,9 @@ jobs:
             compiler: clang
 
           # ARM platforms don't support samples
-          - runs_on: ubuntu-24.04-arm64
+          - runs_on: ubuntu-24.04-arm
             build_type: samples-static
-          - runs_on: ubuntu-24.04-arm64
+          - runs_on: ubuntu-24.04-arm
             build_type: samples-dynamic
           - runs_on: windows-11-arm
             build_type: samples-static

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,32 @@ jobs:
             cmake_build: "cmake --build build --config Debug"
             test_command: "./bin/Debug/test"
 
+          # Ubuntu GCC samples static
+          - name: samples-ubuntu-gcc-static
+            runs_on: ubuntu-latest
+            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
+
+          # Ubuntu GCC ARM64 samples static (cross-compile, samples=OFF)
+          - name: samples-ubuntu-gcc-static-arm64
+            runs_on: ubuntu-latest
+            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
+
+          # macOS samples static
+          - name: samples-macos-static
+            runs_on: macos-latest
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
+
+          # macOS samples dynamic
+          - name: samples-macos-dynamic
+            runs_on: macos-latest
+            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
+            cmake_build: "cmake --build build --config Release"
+
           # Windows x64 samples static
           - name: samples-windows-static
             runs_on: windows-latest
@@ -91,32 +117,6 @@ jobs:
             runs_on: windows-11-arm
             msvc_arch: arm64
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # macOS samples static
-          - name: samples-macos-static
-            runs_on: macos-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # macOS samples dynamic
-          - name: samples-macos-dynamic
-            runs_on: macos-latest
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # Ubuntu GCC samples static
-          - name: samples-ubuntu-gcc-static
-            runs_on: ubuntu-latest
-            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # Ubuntu GCC ARM64 samples static (cross-compile, samples=OFF)
-          - name: samples-ubuntu-gcc-static-arm64
-            runs_on: ubuntu-latest
-            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
             cmake_build: "cmake --build build --config Release"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,24 +8,43 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.runs_on }}-${{ matrix.compiler }}-${{ matrix.build_type }}
-    runs-on: ${{ matrix.runs_on }}
+    name: ${{ matrix.runs_on.id }}-${{ matrix.compiler.id }}-${{ matrix.build_type.id }}
+    runs-on: ${{ matrix.runs_on.runner }}
     timeout-minutes: 10
     strategy:
       matrix:
         runs_on:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
-        compiler: [clang, default]
-        build_type: [basic, samples-static, samples-dynamic]
-        include:
-          # Build type defaults
-          - build_type: basic
+          - id: ubuntu-latest
+            runner: ubuntu-latest
+            test_path: "./bin/test"
+            cmake_system_flags: ""
+          - id: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm64
+            test_path: "./bin/test"
+            cmake_system_flags: ""
+          - id: macos-latest
+            runner: macos-latest
+            test_path: "./bin/test"
+            cmake_system_flags: ""
+          - id: windows-latest
+            runner: windows-latest
+            msvc_arch: x64
+            test_path: "./bin/Debug/test"
+            cmake_system_flags: ""
+          - id: windows-11-arm
+            runner: windows-11-arm
+            msvc_arch: arm64
+            test_path: "./bin/Debug/test"
+            cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
+
+        compiler:
+          - id: clang
+            cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
+          - id: default
+            cmake_compiler_flags: ""
+
+        build_type:
+          - id: basic
             cmake_build_type: Debug
             cmake_samples: OFF
             cmake_shared_libs: OFF
@@ -36,7 +55,7 @@ jobs:
             build_config: Debug
             run_tests: true
 
-          - build_type: samples-static
+          - id: samples-static
             cmake_build_type: Release
             cmake_samples: ON
             cmake_shared_libs: OFF
@@ -47,7 +66,7 @@ jobs:
             build_config: Release
             run_tests: false
 
-          - build_type: samples-dynamic
+          - id: samples-dynamic
             cmake_build_type: Release
             cmake_samples: ON
             cmake_shared_libs: ON
@@ -58,90 +77,45 @@ jobs:
             build_config: Release
             run_tests: false
 
-          # Compiler flags
-          - compiler: clang
-            cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang"
-          - compiler: default
-            cmake_compiler_flags: ""
-
-          # Platform-specific settings
-          - runs_on: ubuntu-latest
-            test_path: "./bin/test"
-            cmake_system_flags: ""
-
-          - runs_on: ubuntu-24.04-arm
-            test_path: "./bin/test"
-            cmake_system_flags: ""
-
-          - runs_on: macos-latest
-            test_path: "./bin/test"
-            cmake_system_flags: ""
-
-          - runs_on: windows-latest
-            msvc_arch: x64
-            test_path: "./bin/Debug/test"
-            cmake_system_flags: ""
-
-          - runs_on: windows-11-arm
-            msvc_arch: arm64
-            test_path: "./bin/Debug/test"
-            cmake_system_flags: "-DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows"
-
-          # Sample deps
-          - runs_on: ubuntu-latest
-            build_type: samples-static
-            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
-          - runs_on: ubuntu-latest
-            build_type: samples-dynamic
-            install_deps: "libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev"
-
         exclude:
-          # Only Ubuntu supports multiple compilers
-          - runs_on: macos-latest
-            compiler: clang
-          - runs_on: windows-latest
-            compiler: clang
-          - runs_on: windows-11-arm
-            compiler: clang
+          # Only Ubuntu supports clang in your original config
+          - runs_on: { id: macos-latest }
+            compiler: { id: clang }
+          - runs_on: { id: windows-latest }
+            compiler: { id: clang }
+          - runs_on: { id: windows-11-arm }
+            compiler: { id: clang }
 
           # ARM platforms don't support samples
-          - runs_on: ubuntu-24.04-arm
-            build_type: samples-static
-          - runs_on: ubuntu-24.04-arm
-            build_type: samples-dynamic
-          - runs_on: windows-11-arm
-            build_type: samples-static
-          - runs_on: windows-11-arm
-            build_type: samples-dynamic
-
-          # Temp disabled
-          # - runs_on: ubuntu-latest
-          #   compiler: clang
-          #   build_type: samples-static
-          # - runs_on: ubuntu-latest
-          #   compiler: clang
-          #   build_type: samples-dynamic
+          - runs_on: { id: ubuntu-24.04-arm64 }
+            build_type: { id: samples-static }
+          - runs_on: { id: ubuntu-24.04-arm64 }
+            build_type: { id: samples-dynamic }
+          - runs_on: { id: windows-11-arm }
+            build_type: { id: samples-static }
+          - runs_on: { id: windows-11-arm }
+            build_type: { id: samples-dynamic }
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        if: ${{ matrix.install_deps }}
-        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.install_deps }}
+      - name: Install dependencies (Ubuntu samples)
+        if: ${{ matrix.runs_on.id == 'ubuntu-latest' && (matrix.build_type.id == 'samples-static' || matrix.build_type.id == 'samples-dynamic') }}
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev
 
       - name: Setup MSVC dev command prompt
-        if: ${{ matrix.msvc_arch }}
+        if: ${{ matrix.runs_on.msvc_arch }}
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
-          arch: ${{ matrix.msvc_arch }}
+          arch: ${{ matrix.runs_on.msvc_arch }}
 
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ${{ matrix.cmake_compiler_flags }} ${{ matrix.cmake_system_flags }} -DBOX2D_SAMPLES=${{ matrix.cmake_samples }} -DBUILD_SHARED_LIBS=${{ matrix.cmake_shared_libs }} -DBOX2D_UNIT_TESTS=${{ matrix.cmake_unit_tests }} -DBOX2D_SANITIZE=${{ matrix.cmake_sanitize }} -DBOX2D_VALIDATE=${{ matrix.cmake_validate }} -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ matrix.cmake_warning_as_error }}
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type.cmake_build_type }} ${{ matrix.compiler.cmake_compiler_flags }} ${{ matrix.runs_on.cmake_system_flags }} -DBOX2D_SAMPLES=${{ matrix.build_type.cmake_samples }} -DBUILD_SHARED_LIBS=${{ matrix.build_type.cmake_shared_libs }} -DBOX2D_UNIT_TESTS=${{ matrix.build_type.cmake_unit_tests }} -DBOX2D_SANITIZE=${{ matrix.build_type.cmake_sanitize }} -DBOX2D_VALIDATE=${{ matrix.build_type.cmake_validate }} -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ matrix.build_type.cmake_warning_as_error }}
 
       - name: Build
-        run: cmake --build build --config ${{ matrix.build_config }}
+        run: cmake --build build --config ${{ matrix.build_type.build_config }}
 
       - name: Test
-        if: ${{ matrix.run_tests }}
+        if: ${{ matrix.build_type.run_tests }}
         working-directory: build
-        run: ${{ matrix.test_path }}
+        run: ${{ matrix.runs_on.test_path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,6 @@ jobs:
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
             cmake_build: "cmake --build build --config Release"
 
-          # Ubuntu GCC ARM64 samples static (cross-compile, samples=OFF)
-          - name: samples-ubuntu-gcc-static-arm64
-            runs_on: ubuntu-latest
-            install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
 
           # macOS samples static
           - name: samples-macos-static
@@ -98,25 +92,11 @@ jobs:
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
             cmake_build: "cmake --build build --config Release"
 
-          # Windows ARM64 samples static
-          - name: samples-windows-static-arm64
-            runs_on: windows-11-arm
-            msvc_arch: arm64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
           # Windows x64 samples dynamic
           - name: samples-windows-dynamic
             runs_on: windows-latest
             msvc_arch: x64
             cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
-            cmake_build: "cmake --build build --config Release"
-
-          # Windows ARM64 samples dynamic
-          - name: samples-windows-dynamic-arm64
-            runs_on: windows-11-arm
-            msvc_arch: arm64
-            cmake_configure: "cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF"
             cmake_build: "cmake --build build --config Release"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  BUILD_TYPE: Debug
-
 jobs:
   build:
     name: ${{ matrix.name }}
@@ -20,53 +17,53 @@ jobs:
           # Ubuntu GCC x64 basic
           - name: ubuntu-gcc
             runs_on: ubuntu-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
             test_command: "./bin/test"
 
           # Ubuntu Clang x64 basic
           - name: ubuntu-clang
             runs_on: ubuntu-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
             test_command: "./bin/test"
 
           # Ubuntu GCC ARM64 basic (cross-compile)
           - name: ubuntu-gcc-arm64
             runs_on: ubuntu-latest
             install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
 
           # Ubuntu Clang ARM64 basic (cross-compile)
           - name: ubuntu-clang-arm64
             runs_on: ubuntu-latest
             install_deps: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
 
           # macOS x64 basic
           - name: macos
             runs_on: macos-latest
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
             test_command: "./bin/test"
 
           # Windows x64 basic
           - name: windows
             runs_on: windows-latest
             msvc_arch: x64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
-            test_command: "./bin/${{env.BUILD_TYPE}}/test"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            test_command: "./bin/Debug/test"
 
           # Windows ARM64 basic
           - name: windows-arm64
             runs_on: windows-11-arm
             msvc_arch: arm64
-            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            cmake_build: "cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
-            test_command: "./bin/${{env.BUILD_TYPE}}/test"
+            cmake_configure: "cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_SYSTEM_NAME=Windows -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            cmake_build: "cmake --build ${{github.workspace}}/build --config Debug"
+            test_command: "./bin/Debug/test"
 
           # Windows x64 samples static
           - name: samples-windows-static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update && \
           sudo apt-get install -y --no-install-recommends \
-          ninja-build gcc-aarch64-linux-gnu
+          ninja-build gcc-aarch64-linux-gnu libc6-dev-arm64-cross
 
           sudo wget https://apt.llvm.org/llvm.sh
           sudo chmod +x llvm.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  release-linux-amd64-web:
-    name: "Release Linux AMD64 and Web"
+  release-linux-amd64-arm64-web:
+    name: "Release Linux AMD64, ARM64 and Web"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update && \
           sudo apt-get install -y --no-install-recommends \
-          ninja-build
+          ninja-build gcc-aarch64-linux-gnu
 
           sudo wget https://apt.llvm.org/llvm.sh
           sudo chmod +x llvm.sh
@@ -38,6 +38,19 @@ jobs:
           -DBOX2D_UNIT_TESTS=OFF \
           -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
 
+          cmake -B ${{github.workspace}}/arm64-build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DBOX2D_DISABLE_SIMD=OFF \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBOX2D_SAMPLES=OFF \
+          -DBOX2D_VALIDATE=OFF \
+          -DBOX2D_UNIT_TESTS=OFF \
+          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+
           emcmake cmake -B ${{github.workspace}}/web-build -GNinja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang-20 \
@@ -53,6 +66,7 @@ jobs:
       - name: Build
         run: |
           cmake --build ${{github.workspace}}/build --config Release
+          cmake --build ${{github.workspace}}/arm64-build --config Release
           cmake --build ${{github.workspace}}/web-build --config Release
 
       - name: Package
@@ -60,10 +74,13 @@ jobs:
           mkdir -p box2d-linux-amd64/src
           cp -r include box2d-linux-amd64
           cp src/*.h box2d-linux-amd64/src
+          cp -r box2d-linux-amd64 box2d-linux-arm64
           cp -r box2d-linux-amd64 box2d-web
           cp build/src/libbox2d.a box2d-linux-amd64
+          cp arm64-build/src/libbox2d.a box2d-linux-arm64
           cp web-build/src/libbox2d.a box2d-web
           tar -czvf box2d-linux-amd64.tar.gz box2d-linux-amd64
+          tar -czvf box2d-linux-arm64.tar.gz box2d-linux-arm64
           tar -czvf box2d-web.tar.gz box2d-web
 
       - name: Create Tag
@@ -81,6 +98,7 @@ jobs:
         with:
           files: |
             ${{github.workspace}}/box2d-linux-amd64.tar.gz
+            ${{github.workspace}}/box2d-linux-arm64.tar.gz
             ${{github.workspace}}/box2d-web.tar.gz
           tag_name: ${{env.TAG}}
           make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,131 +2,131 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   release-linux-amd64-web:
     name: "Release Linux AMD64 and Web"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update && \
-        sudo apt-get install -y --no-install-recommends \
-        ninja-build
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y --no-install-recommends \
+          ninja-build
 
-        sudo wget https://apt.llvm.org/llvm.sh
-        sudo chmod +x llvm.sh
-        sudo ./llvm.sh 20
+          sudo wget https://apt.llvm.org/llvm.sh
+          sudo chmod +x llvm.sh
+          sudo ./llvm.sh 20
 
-    - name: Setup Emscripten
-      uses: mymindstorm/setup-emsdk@v14
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
 
-    - name: Configure CMake
-      run: |
-        cmake -B ${{github.workspace}}/build -GNinja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=clang-20 \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DBOX2D_AVX2=ON \
-        -DBOX2D_DISABLE_SIMD=OFF \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DBOX2D_SAMPLES=OFF \
-        -DBOX2D_VALIDATE=OFF \
-        -DBOX2D_UNIT_TESTS=OFF \
-        -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+      - name: Configure CMake
+        run: |
+          cmake -B ${{github.workspace}}/build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=clang-20 \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DBOX2D_AVX2=ON \
+          -DBOX2D_DISABLE_SIMD=OFF \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBOX2D_SAMPLES=OFF \
+          -DBOX2D_VALIDATE=OFF \
+          -DBOX2D_UNIT_TESTS=OFF \
+          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
 
-        emcmake cmake -B ${{github.workspace}}/web-build -GNinja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=clang-20 \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DBOX2D_AVX2=ON \
-        -DBOX2D_DISABLE_SIMD=OFF \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DBOX2D_SAMPLES=OFF \
-        -DBOX2D_VALIDATE=OFF \
-        -DBOX2D_UNIT_TESTS=OFF \
-        -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+          emcmake cmake -B ${{github.workspace}}/web-build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=clang-20 \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DBOX2D_AVX2=ON \
+          -DBOX2D_DISABLE_SIMD=OFF \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBOX2D_SAMPLES=OFF \
+          -DBOX2D_VALIDATE=OFF \
+          -DBOX2D_UNIT_TESTS=OFF \
+          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
 
-    - name: Build
-      run: |
-        cmake --build ${{github.workspace}}/build --config Release
-        cmake --build ${{github.workspace}}/web-build --config Release
+      - name: Build
+        run: |
+          cmake --build ${{github.workspace}}/build --config Release
+          cmake --build ${{github.workspace}}/web-build --config Release
 
-    - name: Package
-      run: |
-        mkdir -p box2d-linux-amd64/src
-        cp -r include box2d-linux-amd64
-        cp src/*.h box2d-linux-amd64/src
-        cp -r box2d-linux-amd64 box2d-web
-        cp build/src/libbox2d.a box2d-linux-amd64
-        cp web-build/src/libbox2d.a box2d-web
-        tar -czvf box2d-linux-amd64.tar.gz box2d-linux-amd64
-        tar -czvf box2d-web.tar.gz box2d-web
+      - name: Package
+        run: |
+          mkdir -p box2d-linux-amd64/src
+          cp -r include box2d-linux-amd64
+          cp src/*.h box2d-linux-amd64/src
+          cp -r box2d-linux-amd64 box2d-web
+          cp build/src/libbox2d.a box2d-linux-amd64
+          cp web-build/src/libbox2d.a box2d-web
+          tar -czvf box2d-linux-amd64.tar.gz box2d-linux-amd64
+          tar -czvf box2d-web.tar.gz box2d-web
 
-    - name: Create Tag
-      run: |
-        git config user.name "GitHub Actions"
-        git config user.email "github-actions@users.noreply.github.com"
-        TAG="$(echo ${{github.sha}} | head -c 8)"
-        git tag "${TAG}"
-        git push origin "${TAG}"
+      - name: Create Tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          TAG="$(echo ${{github.sha}} | head -c 8)"
+          git tag "${TAG}"
+          git push origin "${TAG}"
 
-        echo "TAG=${TAG}" >> ${GITHUB_ENV}
+          echo "TAG=${TAG}" >> ${GITHUB_ENV}
 
-    - name: Upload Artifact to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          ${{github.workspace}}/box2d-linux-amd64.tar.gz
-          ${{github.workspace}}/box2d-web.tar.gz
-        tag_name: ${{env.TAG}}
-        make_latest: true
+      - name: Upload Artifact to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{github.workspace}}/box2d-linux-amd64.tar.gz
+            ${{github.workspace}}/box2d-web.tar.gz
+          tag_name: ${{env.TAG}}
+          make_latest: true
 
   release-macos-arm64:
     name: "Release macOS ARM64"
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: |
-        cmake -B ${{github.workspace}}/build -GNinja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DBOX2D_DISABLE_SIMD=OFF \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DBOX2D_SAMPLES=OFF \
-        -DBOX2D_VALIDATE=OFF \
-        -DBOX2D_UNIT_TESTS=OFF \
-        -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+      - name: Configure CMake
+        run: |
+          cmake -B ${{github.workspace}}/build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DBOX2D_DISABLE_SIMD=OFF \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBOX2D_SAMPLES=OFF \
+          -DBOX2D_VALIDATE=OFF \
+          -DBOX2D_UNIT_TESTS=OFF \
+          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release
 
-    - name: Package
-      run: |
-        mkdir -p box2d-macos-arm64/src
-        cp build/src/libbox2d.a box2d-macos-arm64
-        cp -r include box2d-macos-arm64
-        cp src/*.h box2d-macos-arm64/src
-        tar -czvf box2d-macos-arm64.tar.gz box2d-macos-arm64
+      - name: Package
+        run: |
+          mkdir -p box2d-macos-arm64/src
+          cp build/src/libbox2d.a box2d-macos-arm64
+          cp -r include box2d-macos-arm64
+          cp src/*.h box2d-macos-arm64/src
+          tar -czvf box2d-macos-arm64.tar.gz box2d-macos-arm64
 
-    - name: Create Tag
-      run: |
-        git config user.name "GitHub Actions"
-        git config user.email "github-actions@users.noreply.github.com"
-        TAG="$(echo ${{github.sha}} | head -c 8)"
-        git tag "${TAG}"
-        git push origin "${TAG}"
+      - name: Create Tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          TAG="$(echo ${{github.sha}} | head -c 8)"
+          git tag "${TAG}"
+          git push origin "${TAG}"
 
-        echo "TAG=${TAG}" >> ${GITHUB_ENV}
+          echo "TAG=${TAG}" >> ${GITHUB_ENV}
 
-    - name: Upload Artifact to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: ${{github.workspace}}/box2d-macos-arm64.tar.gz
-        tag_name: ${{env.TAG}}
-        make_latest: true
+      - name: Upload Artifact to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{github.workspace}}/box2d-macos-arm64.tar.gz
+          tag_name: ${{env.TAG}}
+          make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, ext-build]
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,17 @@ jobs:
             install_deps: |
               sudo apt-get update && \
               sudo apt-get install -y --no-install-recommends ninja-build
-            configure: |
-              cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBOX2D_AVX2=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            configure: >
+              cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBOX2D_AVX2=ON
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=-DB2_MAX_WORLDS=65534
             lib_file: build/src/libbox2d.a
             package_name: box2d-linux-amd64
 
@@ -41,19 +41,19 @@ jobs:
               sudo apt-get update && \
               sudo apt-get install -y --no-install-recommends \
                 ninja-build gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-            configure: |
-              cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
-                -DCMAKE_SYSTEM_NAME=Linux \
-                -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            configure: >
+              cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+              -DCMAKE_SYSTEM_NAME=Linux
+              -DCMAKE_SYSTEM_PROCESSOR=aarch64
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=-DB2_MAX_WORLDS=65534
             lib_file: build/src/libbox2d.a
             package_name: box2d-linux-arm64
 
@@ -63,66 +63,66 @@ jobs:
               sudo apt-get update && \
               sudo apt-get install -y --no-install-recommends ninja-build
             setup_emscripten: true
-            configure: |
-              emcmake cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_AVX2=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            configure: >
+              emcmake cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_AVX2=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=-DB2_MAX_WORLDS=65534
             lib_file: build/src/libbox2d.a
             package_name: box2d-web
 
           - name: macos-arm64
             runner: macos-latest
-            configure: |
-              cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            configure: >
+              cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=-DB2_MAX_WORLDS=65534
             lib_file: build/src/libbox2d.a
             package_name: box2d-macos-arm64
 
           - name: windows-amd64
             runner: windows-latest
             setup_msvc_arch: x64
-            configure: |
-              cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="/DB2_MAX_WORLDS=65534"
+            configure: >
+              cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=/DB2_MAX_WORLDS=65534
             lib_file: build/src/box2d.lib
             package_name: box2d-windows-amd64
 
           - name: windows-arm64
             runner: windows-11-arm
             setup_msvc_arch: arm64
-            configure: |
-              cmake -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_SYSTEM_NAME=Windows \
-                -DCMAKE_SYSTEM_PROCESSOR=ARM64 \
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                -DBOX2D_DISABLE_SIMD=OFF \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBOX2D_SAMPLES=OFF \
-                -DBOX2D_VALIDATE=OFF \
-                -DBOX2D_UNIT_TESTS=OFF \
-                -DCMAKE_C_FLAGS="/DB2_MAX_WORLDS=65534"
+            configure: >
+              cmake -S . -B build -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_SYSTEM_NAME=Windows
+              -DCMAKE_SYSTEM_PROCESSOR=ARM64
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+              -DBOX2D_DISABLE_SIMD=OFF
+              -DBUILD_SHARED_LIBS=OFF
+              -DBOX2D_SAMPLES=OFF
+              -DBOX2D_VALIDATE=OFF
+              -DBOX2D_UNIT_TESTS=OFF
+              -DCMAKE_C_FLAGS=/DB2_MAX_WORLDS=65534
             lib_file: build/src/box2d.lib
             package_name: box2d-windows-arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,147 +4,209 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
-  release-linux-amd64-arm64-web:
-    name: "Release Linux AMD64, ARM64 and Web"
-    runs-on: ubuntu-latest
+  build-packages:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            runner: ubuntu-latest
+            install_deps: |
+              sudo apt-get update && \
+              sudo apt-get install -y --no-install-recommends ninja-build
+            configure: |
+              cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBOX2D_AVX2=ON \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            lib_file: build/src/libbox2d.a
+            package_name: box2d-linux-amd64
+
+          - name: linux-arm64
+            runner: ubuntu-latest
+            install_deps: |
+              sudo apt-get update && \
+              sudo apt-get install -y --no-install-recommends \
+                ninja-build gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+            configure: |
+              cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+                -DCMAKE_SYSTEM_NAME=Linux \
+                -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            lib_file: build/src/libbox2d.a
+            package_name: box2d-linux-arm64
+
+          - name: web
+            runner: ubuntu-latest
+            install_deps: |
+              sudo apt-get update && \
+              sudo apt-get install -y --no-install-recommends ninja-build
+            setup_emscripten: true
+            configure: |
+              emcmake cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_AVX2=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            lib_file: build/src/libbox2d.a
+            package_name: box2d-web
+
+          - name: macos-arm64
+            runner: macos-latest
+            configure: |
+              cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+            lib_file: build/src/libbox2d.a
+            package_name: box2d-macos-arm64
+
+          - name: windows-amd64
+            runner: windows-latest
+            setup_msvc_arch: x64
+            configure: |
+              cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="/DB2_MAX_WORLDS=65534"
+            lib_file: build/src/box2d.lib
+            package_name: box2d-windows-amd64
+
+          - name: windows-arm64
+            runner: windows-11-arm
+            setup_msvc_arch: arm64
+            configure: |
+              cmake -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_SYSTEM_NAME=Windows \
+                -DCMAKE_SYSTEM_PROCESSOR=ARM64 \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DBOX2D_DISABLE_SIMD=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBOX2D_SAMPLES=OFF \
+                -DBOX2D_VALIDATE=OFF \
+                -DBOX2D_UNIT_TESTS=OFF \
+                -DCMAKE_C_FLAGS="/DB2_MAX_WORLDS=65534"
+            lib_file: build/src/box2d.lib
+            package_name: box2d-windows-arm64
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y --no-install-recommends \
-          ninja-build gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        if: ${{ matrix.install_deps }}
+        run: ${{ matrix.install_deps }}
 
-          sudo wget https://apt.llvm.org/llvm.sh
-          sudo chmod +x llvm.sh
-          sudo ./llvm.sh 20
+      - name: Setup MSVC dev command prompt
+        if: ${{ matrix.setup_msvc_arch }}
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        with:
+          arch: ${{ matrix.setup_msvc_arch }}
 
       - name: Setup Emscripten
+        if: ${{ matrix.setup_emscripten }}
         uses: mymindstorm/setup-emsdk@v14
 
       - name: Configure CMake
-        run: |
-          cmake -B ${{github.workspace}}/build -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang-20 \
-          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-          -DBOX2D_AVX2=ON \
-          -DBOX2D_DISABLE_SIMD=OFF \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBOX2D_SAMPLES=OFF \
-          -DBOX2D_VALIDATE=OFF \
-          -DBOX2D_UNIT_TESTS=OFF \
-          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
-
-          cmake -B ${{github.workspace}}/arm64-build -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
-          -DCMAKE_SYSTEM_NAME=Linux \
-          -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
-          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-          -DBOX2D_DISABLE_SIMD=OFF \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBOX2D_SAMPLES=OFF \
-          -DBOX2D_VALIDATE=OFF \
-          -DBOX2D_UNIT_TESTS=OFF \
-          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
-
-          emcmake cmake -B ${{github.workspace}}/web-build -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang-20 \
-          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-          -DBOX2D_AVX2=ON \
-          -DBOX2D_DISABLE_SIMD=OFF \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBOX2D_SAMPLES=OFF \
-          -DBOX2D_VALIDATE=OFF \
-          -DBOX2D_UNIT_TESTS=OFF \
-          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
+        run: ${{ matrix.configure }}
 
       - name: Build
+        run: cmake --build build --config Release
+
+      - name: Package (Unix)
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
         run: |
-          cmake --build ${{github.workspace}}/build --config Release
-          cmake --build ${{github.workspace}}/arm64-build --config Release
-          cmake --build ${{github.workspace}}/web-build --config Release
+          set -euxo pipefail
+          PKG="${{ matrix.package_name }}"
+          mkdir -p "$PKG/src"
+          cp -r include "$PKG"
+          cp src/*.h "$PKG/src"
+          cp "${{ matrix.lib_file }}" "$PKG"
+          cmake -E tar cfv "${PKG}.tar.gz" --format=gnutar "$PKG"
 
-      - name: Package
+      - name: Package (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
         run: |
-          mkdir -p box2d-linux-amd64/src
-          cp -r include box2d-linux-amd64
-          cp src/*.h box2d-linux-amd64/src
-          cp -r box2d-linux-amd64 box2d-linux-arm64
-          cp -r box2d-linux-amd64 box2d-web
-          cp build/src/libbox2d.a box2d-linux-amd64
-          cp arm64-build/src/libbox2d.a box2d-linux-arm64
-          cp web-build/src/libbox2d.a box2d-web
-          tar -czvf box2d-linux-amd64.tar.gz box2d-linux-amd64
-          tar -czvf box2d-linux-arm64.tar.gz box2d-linux-arm64
-          tar -czvf box2d-web.tar.gz box2d-web
+          $pkg="${{ matrix.package_name }}"
+          New-Item -ItemType Directory -Force -Path "$pkg/src" | Out-Null
+          Copy-Item -Recurse -Force include "$pkg"
+          Get-ChildItem -Path src -Filter *.h | Copy-Item -Destination "$pkg/src"
+          Copy-Item -Force "${{ matrix.lib_file }}" "$pkg"
+          cmake -E tar cfv "${pkg}.tar.gz" --format=gnutar "$pkg"
 
-      - name: Create Tag
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "github-actions@users.noreply.github.com"
-          TAG="$(echo ${{github.sha}} | head -c 8)"
-          git tag "${TAG}"
-          git push origin "${TAG}"
-
-          echo "TAG=${TAG}" >> ${GITHUB_ENV}
-
-      - name: Upload Artifact to Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            ${{github.workspace}}/box2d-linux-amd64.tar.gz
-            ${{github.workspace}}/box2d-linux-arm64.tar.gz
-            ${{github.workspace}}/box2d-web.tar.gz
-          tag_name: ${{env.TAG}}
-          make_latest: true
+          name: ${{ matrix.package_name }}
+          path: ${{ matrix.package_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
 
-  release-macos-arm64:
-    name: "Release macOS ARM64"
-    runs-on: macos-latest
+  publish-release:
+    name: Create release and upload assets
+    runs-on: ubuntu-latest
+    needs: build-packages
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure CMake
-        run: |
-          cmake -B ${{github.workspace}}/build -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-          -DBOX2D_DISABLE_SIMD=OFF \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBOX2D_SAMPLES=OFF \
-          -DBOX2D_VALIDATE=OFF \
-          -DBOX2D_UNIT_TESTS=OFF \
-          -DCMAKE_C_FLAGS="-DB2_MAX_WORLDS=65534"
-
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config Release
-
-      - name: Package
-        run: |
-          mkdir -p box2d-macos-arm64/src
-          cp build/src/libbox2d.a box2d-macos-arm64
-          cp -r include box2d-macos-arm64
-          cp src/*.h box2d-macos-arm64/src
-          tar -czvf box2d-macos-arm64.tar.gz box2d-macos-arm64
-
       - name: Create Tag
         run: |
           git config user.name "GitHub Actions"
           git config user.email "github-actions@users.noreply.github.com"
-          TAG="$(echo ${{github.sha}} | head -c 8)"
+          TAG="$(echo ${{ github.sha }} | head -c 8)"
           git tag "${TAG}"
           git push origin "${TAG}"
-
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
 
-      - name: Upload Artifact to Release
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: box2d-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{github.workspace}}/box2d-macos-arm64.tar.gz
-          tag_name: ${{env.TAG}}
+          files: dist/*.tar.gz
+          tag_name: ${{ env.TAG }}
           make_latest: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main, ext-build]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
This essentially revamps how box2d is built and released to go beyond the current setup to include ARM Linux and Windows. Core points:

- This is the successor to #2 (that just added ARM Linux, this also adds Windows and changes the layout). Closes #2.
- I'm happy with how the build workflow is revamped. It went from 164 to 127 lines, thanks to use of the `matrix` feature. But it also started testing new OSs and combinations:
```diff
=ubuntu-clang
+ubuntu-clang-samples-static
+ubuntu-clang-samples-dynamic
=ubuntu
=ubuntu-samples-static
+ubuntu-samples-dynamic
+ubuntu-arm-clang
+ubuntu-arm
=macos
=macos-samples-static
=macos-samples-dynamic
=windows
=windows-samples-static
=windows-samples-dynamic
+windows-arm
```
- Of course the release workflow was revamped too. Now instead of a bunch of cross compilation, all setups are listed out, ran in parallel, and uploaded at the end. Non-ARM Windows, ARM Windows, and ARM Linux releases are added, contributing to the slight increase in line count.